### PR TITLE
Added a ping and a close comandline parameter to enable ping and close messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ telsocket -url <url to ws server> -close -ping
 
 After the connection is established write _ping_ or _close_ and hit enter.
 
-
+Set the maximal payload size per frame (usefull to debug multi-frame messages). Replace _XXX_ with the new maximal payload size.
+```bash
+telsocket -url <url to ws server> -maxframesize=XXX
+```
 
 ![](http://telsocket.org/images/sample.png)

--- a/README.md
+++ b/README.md
@@ -24,5 +24,27 @@ brew install telsocket
 ```bash
 telsocket -url <url to ws server>
 ```
+Send custom headers
+
+```bash
+telsocket -url <url to ws server> -headers name1=value1,name2=value2
+```
+
+Enable `ping` and/or `close` messages
+
+```bash
+telsocket -url <url to ws server> -ping
+```
+```bash
+telsocket -url <url to ws server> -close
+```
+
+```bash
+telsocket -url <url to ws server> -close -ping
+```
+
+After the connection is established write _ping_ or _close_ and hit enter.
+
+
 
 ![](http://telsocket.org/images/sample.png)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ import (
 
 var url = flag.String("url", "", "-url ws://127.0.0.1")
 var headers = flag.String("headers", "", "-headers name1=value1,name2=value2")
+var withPing = flag.Bool("ping", false, "-ping")
+var withClose  = flag.Bool("close", false, "-close")
 
 func main() {
 	flag.Parse()
@@ -30,7 +32,21 @@ func main() {
 	}
 	done := make(chan bool)
 	c := NewClient(*url, headersMap)
-
+	if *withPing {
+		c.SetPongHandler(func(s string) error {
+			fmt.Println("\n", colorRed("PONG rceived:"), colorRed(s))
+			return nil
+		})
+		var defaultPingHandler = c.PingHandler()
+		c.SetPingHandler(func(s string) error {
+			fmt.Println("\n", colorRed("PING rceived:"), colorRed(s))
+			if err := defaultPingHandler(string(s)); err != nil {
+				return err
+			}
+			fmt.Println(colorRed(" PONG sent"))
+			return nil
+		})
+	}
 	go func() {
 		for {
 			_, r, err := c.ReadMessage()
@@ -51,6 +67,15 @@ func main() {
 				return
 			}
 			line = strings.TrimSpace(line)
+			if *withClose && line == "close" {
+				c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+				return
+			}
+			if *withPing && line == "ping" {
+				c.WriteMessage(websocket.PingMessage, []byte{})
+				fmt.Print("\n", colorRed(" PING sent"))
+				continue
+			}
 			if err = c.WriteMessage(1, []byte(line)); err != nil {
 				fmt.Println(err.Error())
 			}
@@ -79,4 +104,7 @@ func NewClient(url string, headers map[string]string) *websocket.Conn {
 
 func color(msg string) string {
 	return ("\033[36m" + msg + "\033[0m")
+}
+func colorRed(msg string) string{
+	return ("\033[31m" + msg + "\033[0m")
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ var url = flag.String("url", "", "-url ws://127.0.0.1")
 var headers = flag.String("headers", "", "-headers name1=value1,name2=value2")
 var withPing = flag.Bool("ping", false, "-ping")
 var withClose  = flag.Bool("close", false, "-close")
+var maxFrameSize = flag.Int("maxframesize", 0, "-maxframesize")
 
 func main() {
 	flag.Parse()
@@ -92,7 +93,20 @@ func NewClient(url string, headers map[string]string) *websocket.Conn {
 	for key, value := range headers {
 		r.Header.Add(key, value)
 	}
-	c, _, err := websocket.DefaultDialer.Dial(url, r.Header)
+	
+	var d websocket.Dialer
+	
+	d = *websocket.DefaultDialer
+	
+	if *maxFrameSize > 0 {
+		d = websocket.Dialer{
+			WriteBufferSize : *maxFrameSize,
+		}
+	}
+	
+	c, _, err := d.Dial(url, r.Header)
+
+	
 	if err != nil {
 		log.Fatal("errrr ", err)
 	} else {


### PR DESCRIPTION
About
---------
This PR adds the possibility to send `ping` and `close` control-frames. 

To enable this feature use the command line flags `-ping` and/or `-close`. This highjacks inputed lines matching `ping` and/or `close` and sends a ping or a close  control-frame and enables some control-frame logging.

Backwards Compatibility Changes:
--------------------------------------------------
None, this breaks no existing features.

![screenshot_20170309_110413](https://cloud.githubusercontent.com/assets/6470959/23745548/e854b7a6-04b8-11e7-87bd-88da9d84b07b.png)
